### PR TITLE
Honor nullability semantics of collection types

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
@@ -63,6 +63,15 @@ internal class KotlinValueInstantiator(src: StdValueInstantiator, private val ca
                 ).wrapWithPath(this.valueClass, jsonProp.name)
             }
 
+            if (jsonProp.type.isCollectionLikeType && paramDef.type.arguments[0].type?.isMarkedNullable == false && (paramVal as Collection<*>).any { it == null }) {
+                val listType = paramDef.type.arguments[0].type
+                throw MissingKotlinParameterException(
+                    parameter = paramDef,
+                    processor = ctxt.parser,
+                    msg = "Instantiation of $listType collection failed for JSON property ${jsonProp.name} due to null value in a collection that does not allow null values"
+                ).wrapWithPath(this.valueClass, jsonProp.name)
+            }
+
             numCallableParameters++
             callableParameters[idx] = paramDef
         }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github27.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github27.kt
@@ -2,6 +2,7 @@ package com.fasterxml.jackson.module.kotlin.test
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.hamcrest.CoreMatchers.equalTo
@@ -34,20 +35,16 @@ class TestGithub27 {
 
     @Test fun testListOfNullableInt() {
         val json = """{"samples":[1, null]}"""
-        val stateObj = mapper.readValue<ClassWithListOfInt>(json)
+        val stateObj = mapper.readValue<ClassWithListOfNullableInt>(json)
         assertThat(stateObj.samples, equalTo(listOf(1, null)))
     }
 
     private data class ClassWithListOfInt(val samples: List<Int>)
 
-    @Ignore("Would be hard to look into generics of every possible type of collection or generic object to check nullability of each item, maybe only possible for simple known collections")
-    @Test fun testListOfInt() {
+    @Test(expected = MissingKotlinParameterException::class)
+    fun testListOfInt() {
         val json = """{"samples":[1, null]}"""
-        val stateObj = mapper.readValue<ClassWithListOfInt>(json)
-        assertTrue(stateObj.samples.none {
-            @Suppress("SENSELESS_COMPARISON")
-            (it == null)
-        })
+        mapper.readValue<ClassWithListOfInt>(json)
     }
 
     // work around to above


### PR DESCRIPTION
This addresses an issue Mike found yesterday where even though you had a contract object of say List<Double>, that list when deserialized could actually contain a null value, which leads to some weird and hard to understand kotlin exceptions.