### PR TITLE
Fix bug with generic property that is a collection

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
@@ -63,7 +63,7 @@ internal class KotlinValueInstantiator(src: StdValueInstantiator, private val ca
                 ).wrapWithPath(this.valueClass, jsonProp.name)
             }
 
-            if (jsonProp.type.isCollectionLikeType && paramDef.type.arguments[0].type?.isMarkedNullable == false && (paramVal as Collection<*>).any { it == null }) {
+            if (jsonProp.type.isCollectionLikeType && paramDef.type.arguments.getOrNull(0)?.type?.isMarkedNullable == false && (paramVal as Collection<*>).any { it == null }) {
                 val listType = paramDef.type.arguments[0].type
                 throw MissingKotlinParameterException(
                     parameter = paramDef,

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github27.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github27.kt
@@ -47,6 +47,14 @@ class TestGithub27 {
         mapper.readValue<ClassWithListOfInt>(json)
     }
 
+    private data class TestClass<T>(val samples: T)
+
+    @Test fun testListOfGeneric() {
+        val json = """{"samples":[1, 2]}"""
+        val stateObj = mapper.readValue<TestClass<List<Int>>>(json)
+        assertThat(stateObj.samples, equalTo(listOf(1, 2)))
+    }
+
     // work around to above
     private class ClassWithListOfIntProtected(val samples: List<Int>) {
         @get:JsonIgnore val safeSamples: List<Int> by lazy { samples.filterNotNull() }


### PR DESCRIPTION
This fixes a bug I introduced in the last commit to add support for nullability type checking of collections. The problem is that if you have a class that has a T field and T is a collection like List<Int>, there's not enough type info to figure out the collection type is Int when deserializing. This is a relatively uncommon case (especially for request objects) and I just hit it because of using a slinkyfit client for a scale only route.