### PR TITLE
Bump to jackson 2.9.6 and use latest version of kotlin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,12 +3,12 @@
     <parent>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-base</artifactId>
-        <version>2.9.4</version>
+        <version>2.9.6</version>
     </parent>
     <groupId>com.fasterxml.jackson.module</groupId>
     <artifactId>jackson-module-kotlin</artifactId>
     <name>jackson-module-kotlin</name>
-    <version>2.9.4-inin-SNAPSHOT</version>
+    <version>2.9.6-inin-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>Add-on module for Jackson (http://jackson.codehaus.org) to support
         Kotlin language, specifically introspection of method/constructor parameter names,
@@ -31,7 +31,7 @@
 
     <properties>
         <version.junit>4.12</version.junit>
-        <version.kotlin>1.2.41</version.kotlin>
+        <version.kotlin>1.2.51</version.kotlin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 


### PR DESCRIPTION
We were starting to get to the point where I couldn't bump other dependencies to the latest because they required a version of Jackson later than what we had.