### PR TITLE
Fix issue with nullable collection

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinValueInstantiator.kt
@@ -63,7 +63,7 @@ internal class KotlinValueInstantiator(src: StdValueInstantiator, private val ca
                 ).wrapWithPath(this.valueClass, jsonProp.name)
             }
 
-            if (jsonProp.type.isCollectionLikeType && paramDef.type.arguments.getOrNull(0)?.type?.isMarkedNullable == false && (paramVal as Collection<*>).any { it == null }) {
+            if (paramVal != null && jsonProp.type.isCollectionLikeType && paramDef.type.arguments.getOrNull(0)?.type?.isMarkedNullable == false && (paramVal as Collection<*>).any { it == null }) {
                 val listType = paramDef.type.arguments[0].type
                 throw MissingKotlinParameterException(
                     parameter = paramDef,

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github27.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github27.kt
@@ -9,6 +9,7 @@ import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Ignore
 import org.junit.Test
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 
@@ -45,6 +46,14 @@ class TestGithub27 {
     fun testListOfInt() {
         val json = """{"samples":[1, null]}"""
         mapper.readValue<ClassWithListOfInt>(json)
+    }
+
+    private data class ClassWithNullableListOfInt(val samples: List<Int>?)
+
+    @Test fun testNullableListOfInt() {
+        val json = """{"samples": null}"""
+        val stateObj = mapper.readValue<ClassWithNullableListOfInt>(json)
+        assertNull(stateObj.samples)
     }
 
     private data class TestClass<T>(val samples: T)


### PR DESCRIPTION
We haven't seen this until now since wfm service doesn't use null collections. But if there is a null collection, we were missing the null check and trying to cast null to a Collection<*>, which was failing.