### PR TITLE
Fix serde of properties beginning with is

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.fasterxml.jackson.module</groupId>
     <artifactId>jackson-module-kotlin</artifactId>
     <name>jackson-module-kotlin</name>
-    <version>2.9.8-inin-SNAPSHOT</version>
+    <version>2.9.8.1-inin-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>Add-on module for Jackson (http://jackson.codehaus.org) to support
         Kotlin language, specifically introspection of method/constructor parameter names,

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -92,7 +92,7 @@ internal class KotlinNamesAnnotationIntrospector(val module: KotlinModule, val c
         if (member is AnnotatedParameter) {
             return findKotlinParameterName(member)
         } else if (member is AnnotatedMethod) {
-            if (member.declaringClass.isKotlinClass() && member.rawReturnType == Boolean::class.java) {
+            if (member.declaringClass.isKotlinClass() && member.rawReturnType == Boolean::class.java && member.name.startsWith("is")) {
                 if (cache.isKotlinGeneratedBooleanMethod(member, { it.declaringClass.declaredFields.any { f -> f.name == member.name } })) {
                     return member.name
                 }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github80.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/test/Github80.kt
@@ -1,0 +1,36 @@
+package com.fasterxml.jackson.module.kotlin.test
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class Github80 {
+
+    @Test
+    fun testIsBool() {
+        val mapper = jacksonObjectMapper()
+
+        val example = IsBoolExample(true)
+        val json = mapper.writeValueAsString(example)
+        assertEquals("{ isTrueOrFalse: true }", json)
+
+        val deserialized = mapper.readValue(json, IsBoolExample::class.java)
+        assertEquals(example.isTrueOrFalse, deserialized.isTrueOrFalse)
+    }
+
+    @Test
+    fun testGetProperty() {
+        val mapper = jacksonObjectMapper()
+
+        val example = GetExample(1)
+        val json = mapper.writeValueAsString(example)
+        assertEquals("{ getGetProp: 1 }", json)
+
+        val deserialized = mapper.readValue(json, GetExample::class.java)
+        assertEquals(example.getProp, deserialized.getProp)
+    }
+
+    class IsBoolExample(val isTrueOrFalse: Boolean)
+
+    class GetExample(val getProp: Int)
+}


### PR DESCRIPTION
This should solve the annoying and potentially risky problem of booleans not being serialized property if prefixed with "is". Fully explanation can be found here: https://github.com/FasterXML/jackson-module-kotlin/issues/80. I'm probably going to wait a bit to merge this to see if there are any comments on the issue about better ways and also to do some more testing with our schemas. I'm also going add a 4th version on the pom (first 3 correlation with jackson release) so that it's opt-in to further reduce the risk.